### PR TITLE
Add configurable per-rule delay before running actions

### DIFF
--- a/SimpleKVM/GUI/Rules/ModifyRule.Designer.cs
+++ b/SimpleKVM/GUI/Rules/ModifyRule.Designer.cs
@@ -35,7 +35,10 @@
             txtRuleName = new System.Windows.Forms.TextBox();
             btnTest = new System.Windows.Forms.Button();
             label2 = new System.Windows.Forms.Label();
+            lblDelay = new System.Windows.Forms.Label();
+            nudDelay = new System.Windows.Forms.NumericUpDown();
             ((System.ComponentModel.ISupportInitialize)errorProvider1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDelay).BeginInit();
             SuspendLayout();
             // 
             // btnSave
@@ -95,12 +98,35 @@
             label2.Size = new System.Drawing.Size(182, 15);
             label2.TabIndex = 4;
             label2.Text = "(will revert back after 10 seconds)";
-            // 
+            //
+            // lblDelay
+            //
+            lblDelay.AutoSize = true;
+            lblDelay.Location = new System.Drawing.Point(8, 42);
+            lblDelay.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            lblDelay.Name = "lblDelay";
+            lblDelay.Size = new System.Drawing.Size(65, 15);
+            lblDelay.TabIndex = 5;
+            lblDelay.Text = "Delay (s):";
+            //
+            // nudDelay
+            //
+            nudDelay.Location = new System.Drawing.Point(81, 39);
+            nudDelay.Margin = new System.Windows.Forms.Padding(2);
+            nudDelay.Maximum = new decimal(new int[] { 3600, 0, 0, 0 });
+            nudDelay.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            nudDelay.Name = "nudDelay";
+            nudDelay.Size = new System.Drawing.Size(60, 23);
+            nudDelay.TabIndex = 1;
+            nudDelay.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            //
             // ModifyRule
-            // 
+            //
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             ClientSize = new System.Drawing.Size(424, 186);
+            Controls.Add(nudDelay);
+            Controls.Add(lblDelay);
             Controls.Add(label2);
             Controls.Add(btnTest);
             Controls.Add(txtRuleName);
@@ -110,6 +136,7 @@
             Name = "ModifyRule";
             Text = "ModifyRule";
             ((System.ComponentModel.ISupportInitialize)errorProvider1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDelay).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -122,5 +149,7 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnTest;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label lblDelay;
+        private System.Windows.Forms.NumericUpDown nudDelay;
     }
 }

--- a/SimpleKVM/GUI/Rules/ModifyRule.cs
+++ b/SimpleKVM/GUI/Rules/ModifyRule.cs
@@ -57,6 +57,7 @@ namespace SimpleKVM.GUI.Rules
             if (ruleToEdit != null)
             {
                 txtRuleName.Text = ruleToEdit.Name;
+                nudDelay.Value = ruleToEdit.DelaySeconds;
             }
 
             UserControl? triggerCreatorUc = triggerType switch
@@ -70,7 +71,7 @@ namespace SimpleKVM.GUI.Rules
             if (triggerCreatorUc != null)
             {
                 triggerCreatorUc.Left = label1.Left;
-                triggerCreatorUc.Top = txtRuleName.Bottom + 8;
+                triggerCreatorUc.Top = nudDelay.Bottom + 8;
 
                 Controls.Add(triggerCreatorUc);
 
@@ -157,7 +158,10 @@ namespace SimpleKVM.GUI.Rules
 
                 if (trigger != null && actions != null)
                 {
-                    result = new Rule(txtRuleName.Text, trigger, actions);
+                    result = new Rule(txtRuleName.Text, trigger, actions)
+                    {
+                        DelaySeconds = (int)nudDelay.Value
+                    };
                 }
 
                 return result;
@@ -165,6 +169,7 @@ namespace SimpleKVM.GUI.Rules
             else
             {
                 RuleToEdit.Name = txtRuleName.Text;
+                RuleToEdit.DelaySeconds = (int)nudDelay.Value;
                 RuleToEdit.Trigger = triggerCreator?.GetTrigger() ?? RuleToEdit.Trigger;
                 RuleToEdit.Actions = actionCreator?.GetAction() ?? RuleToEdit.Actions;
 

--- a/SimpleKVM/Rules/Rule.cs
+++ b/SimpleKVM/Rules/Rule.cs
@@ -17,6 +17,7 @@ namespace SimpleKVM.Rules
         public DateTime? LastRun { get; set; }
         public EnumRuleStatus Status { get; set; } = EnumRuleStatus.Stopped;
         public string Name { get; set; } = "";
+        public int DelaySeconds { get; set; }
 
         public Rule(string name, Trigger trigger, List<IAction> actions)
         {
@@ -59,6 +60,9 @@ namespace SimpleKVM.Rules
 
         public void Run()
         {
+            if (DelaySeconds > 0)
+                System.Threading.Thread.Sleep(DelaySeconds * 1000);
+
             bool wasRun = false;
             Actions
                 .ForEach(action =>


### PR DESCRIPTION
Adds a per-rule delay so a rule can wait before running its actions.

- New `DelaySeconds` property on `Rule`.
- Surfaced as a NumericUpDown in the rule edit dialog (`ModifyRule`).
- `Rule.Run()` waits the configured number of seconds before executing actions.

Useful for letting a monitor or USB device settle after the trigger fires before the source switch is issued.

## Why?

The device you switch to often has to wake up before it starts driving a video signal to the monitor. If the monitor input is switched before the device is awake, the monitor sees no signal on the new input and reverts to the previous input that still has one. 
A configurable delay leaves time to wake the target device first - for example by pressing a key or moving the mouse on the USB-switched peripherals - so that an active signal is present by the time the monitor input changes over.

## Screenshot

<img width="813" height="522" alt="image" src="https://github.com/user-attachments/assets/be577427-4548-405b-a77e-48ab87dd52db" />
